### PR TITLE
Do not throw on missing dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,14 @@ function fetchDependency(source, filename, resolveModuleToPath) {
 	resolveModuleToPath = resolveModuleToPath || getFullPath;
 	var fullPath = resolveModuleToPath(source, filename);
 	if (!hasFile[fullPath]) {
-		filesToCompile.push({
-			contents: fs.readFileSync(fullPath, 'utf8'),
-			options: {filename: fullPath}
-		});
+		if (fs.existsSync(fullPath)) {
+			filesToCompile.push({
+				contents: fs.readFileSync(fullPath, 'utf8'),
+				options: {filename: fullPath}
+			});
+		} else {
+			console.warn('Could not find ' + fullPath);
+		}
 		hasFile[fullPath] = true;
 	}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,19 @@ module.exports = {
 		test.done();
 	},
 
+	testMissingDependency: function(test) {
+		var files = [{
+			contents: 'import foo from "/missing/path/foo";',
+			options: {filename: path.resolve('test/assets/missing.js')}
+		}];
+
+		assert.doesNotThrow(function() {
+			babelDeps(files);
+		});
+
+		test.done();
+	},
+
 	testCompileWithResolveModuleSource: function(test) {
 		var files = [
 			{


### PR DESCRIPTION
Hey Maíra!

I'd like to just show a warning if for any reason a missing dependency. With this, we could add an extra `import soyutils...` directive inside `SoyComponent.js` in our build process in portal before fetching it to babel.

This way, we will be able to just use any `crystal-components` that depends on `SoyComponent` without having to manually specify the dependency all the time.

What do you think?

PS: There's one broken test you might want to look at ;) 
